### PR TITLE
Add unique constraint to referential table

### DIFF
--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -59,6 +59,7 @@ create table referential(
     , root boolean
     , srid int
     , sensor int references sensor(id)
+    , constraint uniqreferential unique(name, sensor)
 );
 
 create table session(


### PR DESCRIPTION
This PR adds a unique constraint on `(name, sensor)` to the `referential` table. This is to able to determine if the referentials in a blinis file are already present in the database.

@mbredif is this the unique constraint you had in mind ([comment](https://github.com/LI3DS/micmac_li3ds/commit/98955599e1a993b8b7788d623e7ebcd8da8e8e14#commitcomment-21348025))?