### PR TITLE
Make Travis cache the .pyembedpg dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+cache:
+  directories:
+  - $HOME/.pyembedpg
 python:
   - "3.4"
   - "3.5"


### PR DESCRIPTION
With this commit we make Travis cache the .pyembedpg dir and reuse it from one build to the other. With this the build time goes from 5 minutes to 1 minute.

For example, compare https://travis-ci.org/elemoine/pg_li3ds/builds/211834412 (cold cache) to https://travis-ci.org/elemoine/pg_li3ds/builds/211837078 (hot cache).

closes #12