### PR TITLE
Use Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: python
 cache:
   directories:


### PR DESCRIPTION
The Travis build is currently broken. See https://travis-ci.org/elemoine/pg_li3ds/jobs/229095956 for example. This PR fixes it by using Trusty instead of Precise.