### PR TITLE
Improve the create_project function

### DIFF
--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -296,7 +296,7 @@ begin
 
     execute format('create table %I.image(
           id bigserial primary key
-          , filename varchar
+          , uri varchar
           , exif jsonb
           , etime timestamptz
           , datasource bigint references li3ds.datasource(id) on delete cascade

--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -302,6 +302,18 @@ begin
           , datasource bigint references li3ds.datasource(id) on delete cascade
         );', $1);
 
+    execute format('create table %I.route(
+          id bigserial primary key
+          , uri varchar
+          , datasource bigint references li3ds.datasource(id) on delete cascade
+      );', $1);
+
+    execute format('create table %I.lidar(
+          id bigserial primary key
+          , uri varchar
+          , datasource bigint references li3ds.datasource(id) on delete cascade
+      );', $1);
+
     RETURN proj_id;
 END;
 $$ language plpgsql;

--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -300,18 +300,21 @@ begin
           , exif jsonb
           , etime timestamptz
           , datasource bigint references li3ds.datasource(id) on delete cascade
+          , constraint uniqimageuri unique(uri, datasource)
         );', $1);
 
     execute format('create table %I.route(
           id bigserial primary key
           , uri varchar
           , datasource bigint references li3ds.datasource(id) on delete cascade
+          , constraint uniqrouteuri unique(uri, datasource)
       );', $1);
 
     execute format('create table %I.lidar(
           id bigserial primary key
           , uri varchar
           , datasource bigint references li3ds.datasource(id) on delete cascade
+          , constraint uniqlidaruri unique(uri, datasource)
       );', $1);
 
     RETURN proj_id;

--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -292,7 +292,7 @@ begin
 	    values (%L, %L, %L::geometry) returning id', $1, $2, $3)
         into proj_id;
 
-    execute format('create schema %I', lower($1));
+    execute format('create schema %I', $1);
 
     execute format('create table %I.image(
           id bigserial primary key
@@ -300,7 +300,7 @@ begin
           , exif jsonb
           , etime timestamptz
           , datasource bigint references li3ds.datasource(id) on delete cascade
-        );', lower($1));
+        );', $1);
 
     RETURN proj_id;
 END;

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,13 +103,17 @@ def test_table_list(db):
 
 def test_create_project(db):
     '''
-    When create_project is invoked, a new schema must be created in addition to
-    a new table and an entry in project table
+    When create_project is called the following should be created:
+    - a new schema
+    - "image", "route" and "lidar" tables
+    - a new record in the li3ds.project table
     '''
-    db.execute("select create_project('paris', 'Europe/Paris')")
-    assert db.hasschema("paris")
-    assert db.query("select name from project") == [('paris',)]
-    assert db.hastable('paris', "image")
+    db.execute("select create_project('Paris', 'Europe/Paris')")
+    assert db.hasschema("Paris")
+    assert db.query("select name from project") == [('Paris',)]
+    assert db.hastable('Paris', 'image')
+    assert db.hastable('Paris', 'route')
+    assert db.hastable('Paris', 'lidar')
 
 
 def test_create_project_dup(db):


### PR DESCRIPTION
This brings a number of improvements to the create_project function.

* `image.filname` changed to `image.uri`, as discussed
* project names may include capital letters, so project schema names may also include capital letters
* `create_project` should also create "route" and "lidar" tables
* make image/lidar/route URIs unique within a datasource

@ldgeo, can you please take a look at this? I'd like to understand why create_project did not create "route" and "lidar" tables previously. Was there a good reason?